### PR TITLE
Fix intermittent error when recording using specified mic

### DIFF
--- a/swift/aperture/Recorder.swift
+++ b/swift/aperture/Recorder.swift
@@ -36,7 +36,10 @@ public class Recorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     }
 
     self.output = AVCaptureMovieFileOutput();
-    self.output?.movieFragmentInterval = CMTimeMake(1,1); // write data to file every 1 second
+
+    // write data to file every 2 seconds
+    // writing every 1 second causes intermittent errors
+    self.output?.movieFragmentInterval = CMTimeMakeWithSeconds(2, 1);
 
     if ((self.session?.canAddOutput(self.output)) != nil) {
       self.session?.addOutput(self.output);


### PR DESCRIPTION
No more "FigMovieFormatFileWriter::PostProcessMovie: WriteMovie() errored!!! -12780"!